### PR TITLE
Updated to 0.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cdk-iac
 
-**24/01/19 - Updated to CDK 0.22.0**
+**26/04/19 - Updated to CDK 0.29.0**
 =======
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ce2687a9e0834453afd03e40752dd4d3)](https://app.codacy.com/app/markhaskins/cdk-iac?utm_source=github.com&utm_medium=referral&utm_content=githublemming/cdk-iac&utm_campaign=Badge_Grade_Dashboard)
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>0.22.0</cdk.version>
+        <cdk.version>0.29.0</cdk.version>
     </properties>
 
     <build>

--- a/src/main/java/io/haskins/cdkiac/stack/application/InfluxDb.java
+++ b/src/main/java/io/haskins/cdkiac/stack/application/InfluxDb.java
@@ -144,7 +144,7 @@ public class InfluxDb extends CdkIacStack {
                     .withLaunchConfigurationName(lc.getLaunchConfigurationName())
                     .withMaxSize("1")
                     .withMinSize("1")
-                    .withVpcZoneIdentifier(appProps.getPropAsObjectList("ec2Subnets"))
+                    .withVpcZoneIdentifier(appProps.getPropAsStringList("ec2Subnets"))
                     .build());
 
 

--- a/src/test/java/io/haskins/cdkiac/stack/infrastructure/S3Test.java
+++ b/src/test/java/io/haskins/cdkiac/stack/infrastructure/S3Test.java
@@ -29,6 +29,8 @@ public class S3Test extends BaseTest {
         } catch (StackException e) {
             Assert.fail("Failed to create stack");
         }
-        System.out.println(createYaml(s3.toCloudFormation()));
+//        System.out.println(createYaml(s3.toCloudFormation()));
+
+//        assert.SynthUtils.toCloudFormation(s3);
     }
 }


### PR DESCRIPTION
Updated to 0.29.0

Unit tests work put on hold as was-cdk/assert not available yet for Java. This is needed to get the CF template from the code, to perform tests against it